### PR TITLE
default is now dynamic depending on java version used

### DIFF
--- a/test/test_bitescript.rb
+++ b/test/test_bitescript.rb
@@ -4,8 +4,15 @@ require 'test/unit'
 require 'bitescript'
 
 class TestBitescript < Test::Unit::TestCase
+  def test_bytecode_defaults_to_current_version
+    spec_version = ENV_JAVA['java.specification.version']
+    expected_version = BiteScript.const_get("JAVA#{spec_version.gsub('.', '_')}")
+
+    assert_equal expected_version, BiteScript.bytecode_version
+  end
+
   def test_bytecode_version
-    assert_equal BiteScript::JAVA1_4, BiteScript.bytecode_version
+    
     [BiteScript::JAVA1_4, BiteScript::JAVA1_5, BiteScript::JAVA1_6].each do |ver|
       BiteScript.bytecode_version = ver
       assert_equal(ver, BiteScript.bytecode_version)


### PR DESCRIPTION
fixes test so that it will pass regardless of the java version the test is executed with.
