### PR TITLE
Tweaks to get Bitescript going in JRuby 1.6.3 in --1.9 mode

### DIFF
--- a/bitescript.gemspec
+++ b/bitescript.gemspec
@@ -4,7 +4,7 @@ Gem::Specification.new do |s|
   s.name = %q{bitescript}
   s.version = "0.0.9"
   s.authors = ["Charles Oliver Nutter", "Ryan Brown"]
-  s.date = Time.now.strftime('YYYY-MM-DD')
+  s.date = Time.now.strftime('%Y-%m-%d')
   s.description = %q{BiteScript is a Ruby DSL for generating Java bytecode and classes.}
   s.email = ["headius@headius.com", "ribrdb@gmail.com"]
   s.executables = ["bite", "bitec"]

--- a/examples/hello_world_macro.bs
+++ b/examples/hello_world_macro.bs
@@ -4,20 +4,24 @@ import java.io.PrintStream
 macro :aprintln do
   getstatic System, :out, PrintStream
   swap
-  invokevirtual PrintStream, println, [Object]
+  invokevirtual PrintStream, "println", [void, object]
 end
 
 macro :aprint do
   getstatic System, :out, PrintStream
   swap
-  invokevirtual PrintStream, print, [Object]
+  invokevirtual PrintStream, "print", [void, object]
 end
 
 main do
   ldc "Hello, "
   aprint
+
+  # Get first argument from command line
   aload 0
-  aaload 0
+  ldc 0
+  aaload
+
   aprintln
   returnvoid
 end

--- a/lib/bitescript/bytecode.rb
+++ b/lib/bitescript/bytecode.rb
@@ -39,7 +39,7 @@ module BiteScript
     
     OpcodeInstructions = {}
 
-    Opcodes.constants.each do |const_name|
+    Opcodes.constants.map(&:to_s).each do |const_name|
       const_down = const_name.downcase
       
       case const_name


### PR DESCRIPTION
These commits tweak Bitescript (plus its build files and examples) to work in JRuby 1.6.3 in --1.9 mode.  Together, they do the following:

1) Fix bytecode.rb, which assumes the contents of ASM's Opcodes constant are strings (they are symbols in --1.9 mode).

2) Update hello_world_macro.bs to run without errors.

3) Update the gemspec to use a time format recognized by strftime.
